### PR TITLE
HUGE speedup by using fastpbkdf2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 target
 Cargo.lock
+callgrind*
+build.sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 
 [dependencies]
 rust-crypto = "~0.2"
-rust_sodium = "~0.1.2"
+fastpbkdf2 = "~0.1.0"
 rand = "~0.3"
 
 [dev-dependencies]


### PR DESCRIPTION
The windows build is likely to still be broken, but this doesn't make things worse.

On the contrary, on *nix, the speedup is HUGE. We went from 35.000.000 ns/iter for encryption down to 18.000.000 ns/iter, thanks to `fastpbkdf2` and callgrind.